### PR TITLE
chore: improve Dockerfile (ffmpeg recommends, non-root, healthcheck)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,10 +1,11 @@
 node_modules
-npm-debug.log
+npm-debug.log*
 .git
-.gitignore
 .github
+.gitignore
+.gitattributes
 .env
-.env.test
+.env.*
 *.log
 videos
 temp
@@ -13,5 +14,9 @@ ffmpeg.exe
 .DS_Store
 README.md
 LICENSE
-.gitattributes
+Dockerfile
+.dockerignore
+docker-compose.yml
+.vscode
+.idea
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,32 +1,31 @@
-# Use Node.js LTS as base image
-FROM node:20-slim
+# syntax=docker/dockerfile:1
 
-# Install ffmpeg and other dependencies
-RUN apt-get update && \
-    apt-get install -y ffmpeg && \
-    apt-get clean && \
-    rm -rf /var/lib/apt/lists/*
+# Express + ffmpeg video watermarker. ffmpeg is required at runtime (large);
+# keep Debian slim, avoid recommends, run as non-root with writable dirs.
 
-# Set working directory
+FROM node:22-bookworm-slim
+
 WORKDIR /app
 
-# Copy package files
-COPY package*.json ./
+ENV NODE_ENV=production
 
-# Install dependencies
-RUN npm ci --only=production
+RUN apt-get update \
+  && apt-get install -y --no-install-recommends ffmpeg \
+  && rm -rf /var/lib/apt/lists/*
 
-# Copy application files
-COPY index.mjs ./
-COPY Wanderstories-logo.png ./
-COPY favicon.ico ./
+COPY package.json package-lock.json ./
+RUN npm ci --omit=dev && npm cache clean --force
 
-# Create necessary directories
-RUN mkdir -p temp videos
+COPY index.mjs Wanderstories-logo.png favicon.ico ./
 
-# Expose port (default, can be overridden via environment)
+RUN mkdir -p temp videos \
+  && chown -R node:node /app
+
+USER node
+
 EXPOSE 8090
 
-# Run the application
-CMD ["node", "index.mjs"]
+HEALTHCHECK --interval=30s --timeout=10s --start-period=20s --retries=3 \
+  CMD node -e "require('http').get('http://127.0.0.1:'+(process.env.PORT||8090)+'/', (r) => process.exit(r.statusCode===200?0:1)).on('error', () => process.exit(1))"
 
+CMD ["node", "index.mjs"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,7 @@ RUN npm ci --omit=dev && npm cache clean --force
 COPY index.mjs Wanderstories-logo.png favicon.ico ./
 
 RUN mkdir -p temp videos \
-  && chown -R node:node /app
+  && chown -R node:node /app/temp /app/videos
 
 USER node
 


### PR DESCRIPTION
﻿## Summary
Express + ffmpeg watermark proxy. Kept Debian (ffmpeg needs it), tightened apt install, non-root runtime, and HEALTHCHECK.

## Suboptimal → changes → why
| Issue | Change | Why |
|-------|--------|-----|
| `apt-get install ffmpeg` without `--no-install-recommends` | Add flag + clean lists | Smaller ffmpeg layer |
| `node:20-slim` | `node:22-bookworm-slim` | Explicit Debian + current LTS |
| Root user | `USER node` + chown `temp`/`videos` | Least privilege with writable dirs |
| No image HEALTHCHECK | Node HTTP check on `/` | Align with compose |
| Loose `.dockerignore` | Exclude Docker/IDE noise | Smaller context |

## Deliberate skips
- **Multi-stage (DF011)**: ffmpeg must be in the final image; splitting npm install alone is not worth the complexity.
- **Alpine**: ffmpeg/musl pain; Debian retained deliberately.
- **Static/ffmpeg-minimal custom builds**: higher maintenance than distro ffmpeg for this proxy.

## Image sizes
| Tag | Size |
|-----|------|
| Before | **1.18GB** |
| After | **997MB** |

## Build / verify
- Clean rebuild: success
- Smoke: `GET /` OK; `ffmpeg -version` present

## dockerfile-roast notes
**Before:** DF020, DF012, DF011, DF016
**After:** DF011 (+ DF005 info on apt versions)

## Remaining recommendations
- Consider a dedicated ffmpeg base if further size cuts are needed
- Optional digest pin


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Updated the application’s container environment for improved production reliability and compatibility.
  * Added automatic health monitoring to help detect service availability issues.
  * Improved media-processing support and ensured required runtime directories are writable.
  * Enhanced security by running the application with a non-administrative account.
  * Streamlined production installation and deployment configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->