### PR TITLE
Add Claude BugBot PR review action

### DIFF
--- a/.github/workflows/bugbot.yml
+++ b/.github/workflows/bugbot.yml
@@ -1,0 +1,41 @@
+# Claude BugBot — automated PR bug review via Claude Code CLI
+# https://github.com/marketplace/actions/claude-bugbot
+#
+# Setup (one-time):
+# 1. Run `claude setup-token` locally and copy the OAuth token (sk-ant-oat01-...)
+# 2. Repo Settings → Secrets and variables → Actions → New repository secret
+#    Name: CLAUDE_SETUP_TOKEN
+#    Value: the token from step 1
+# 3. Repo Settings → Actions → General → Workflow permissions →
+#    "Read and write permissions" (required for inline review comments)
+
+name: Claude BugBot
+
+on:
+  pull_request:
+    types: [opened, synchronize]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  bugbot:
+    runs-on: ubuntu-latest
+    if: github.actor != 'dependabot[bot]'
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v7.0.1
+        with:
+          # Full history enables BugBot's git-history lens (detects silently undone fixes)
+          fetch-depth: 0
+
+      - name: Run Claude BugBot
+        uses: rekpero/claude-bugbot-github-action@v1.0.14
+        with:
+          claude-setup-token: ${{ secrets.CLAUDE_SETUP_TOKEN }}
+          # Optional alternatives / overrides:
+          # anthropic-api-key: ${{ secrets.ANTHROPIC_API_KEY }}
+          # model: sonnet
+          # max-budget: '1.00'
+          # github-token: ${{ secrets.GH_PAT }}  # PAT with repo scope if thread resolve fails


### PR DESCRIPTION
## Summary
- Add `.github/workflows/bugbot.yml` using [Claude BugBot](https://github.com/marketplace/actions/claude-bugbot) for automated inline PR bug reviews.
- Uses `actions/checkout@v7.0.1` and `rekpero/claude-bugbot-github-action@v1.0.14`.
- Skips Dependabot PRs; full git history for the history lens.

## Setup required after merge
1. Add repository secret `CLAUDE_SETUP_TOKEN` (from `claude setup-token`):
   **Settings → Secrets and variables → Actions → New repository secret**
2. Confirm **Settings → Actions → General → Workflow permissions** is **Read and write permissions**.

Optional: if thread auto-resolve fails, add classic PAT (`repo` scope) as `GH_PAT` and uncomment `github-token` in the workflow.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automated bug detection for pull requests.
  * Bug checks run when pull requests are opened or updated, with Dependabot-triggered events excluded.
  * Added configurable options for the analysis service, including API credentials, model, budget, and GitHub token settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->