### PR TITLE
Add AGENTS.md and PR merge guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,34 @@
+# AGENTS.md
+
+Agent-focused guidance for this repository ([AGENTS.md format](https://agents.md/)). Human-facing docs live in `README.md`.
+
+Treat this file as living documentation: update it when the stack, scripts, or project facts change.
+
+## Project overview
+
+Wanderstories video watermark proxy: Express + ffmpeg.
+
+## Setup
+
+Requires Node.js and ffmpeg on PATH (`ffmpeg.exe` next to the repo on Windows, or `apt`/`brew` install).
+
+```bash
+npm install
+npm start
+npm run dev
+npm run lint
+```
+
+## Conventions
+
+- Run `npm run lint` after JS changes; fix issues before finishing.
+- Sanitize filenames and user input; keep Helmet / CSRF / rate-limit behavior intact.
+- Never commit secrets or uploaded media.
+
+
+## Pull requests
+
+Before merging any pull request:
+
+1. **Read all comments** on the PR — conversation comments, review comments (including those on specific lines), and bot comments. Address or acknowledge them. Do not merge while review feedback is unresolved.
+2. **Wait for CI to complete successfully.** GitHub Actions (and other required checks) on the PR must finish and pass. Do not merge while checks are pending, failed, cancelled, or skipped when they are required. If CI fails, fix the cause and wait for a green run before merging.


### PR DESCRIPTION
## Summary
- Add or update `AGENTS.md` as the agent source of truth ([agents.md](https://agents.md/)).
- Migrate any `.cursor/rules/*.mdc` into `AGENTS.md` and remove those Cursor rule files.
- Instruct agents to **read all PR comments** and **wait for CI to succeed** before merging.

## Test plan
- [ ] Confirm `AGENTS.md` is present and includes the Pull requests section
- [ ] Confirm `.cursor/rules` is gone if it previously existed
